### PR TITLE
Fix: Update root page to redirect authenticated users to /create

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -1,8 +1,18 @@
+"use client";
+
 import { BookUp2, Pickaxe } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
+import { useEffect } from "react";
 
 export default function Home() {
+    useEffect(() => {
+        // Check if user is already logged in
+        if (localStorage.getItem("id")) {
+            window.location.href = "/create";
+        }
+    }, []);
+
     return (
         <div className="min-h-screen flex flex-col items-center justify-between p-8 sm:p-20 bg-background font-[family-name:var(--font-geist-mono)]">
             <main className="flex flex-col items-center gap-6 flex-grow justify-center">


### PR DESCRIPTION
Issue:-
When logged-in users clicked "Back to Home" from the /create page, they were redirected to the root path /. However, the root page did not check authentication status, so it displayed only a "Get Started" button that led to /auth — effectively forcing users to re-login and breaking the expected session flow.

Solution: 
Modified the root page (page.js) to check for user authentication using localStorage.getItem("id") and automatically redirect authenticated users to /create, while preserving the original landing page behavior for non-authenticated users.

Why this is the best approach: 
This solution maintains the existing navigation struccture while adding intelligent authentication-aware routing. It's minimal, doesn't break existing functionality, and provides a seamless user experience by keeping authenticated users in the app's authenticated area rather than forcing them through the login flow again.