### PR TITLE
Fix: Update root page to redirect authenticated users to /create

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -1,8 +1,18 @@
+"use client";
+
 import { BookUp2, Pickaxe } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
+import { useEffect } from "react";
 
 export default function Home() {
+    useEffect(() => {
+        // Check if user is already logged in
+        if (localStorage.getItem("id")) {
+            window.location.href = "/create";
+        }
+    }, []);
+
     return (
         <div className="min-h-screen flex flex-col items-center justify-between p-8 sm:p-20 bg-background font-[family-name:var(--font-geist-mono)]">
             <main className="flex flex-col items-center gap-6 flex-grow justify-center">


### PR DESCRIPTION
### What I fixed
- Resolved the issue where authenticated users returning to `/` were not properly redirected or shown the right content.
- Now, if a user is already logged in and lands on the root route (`/`), they are automatically redirected to `/create`.

### Why it's needed
- Previously, users would get stuck on `/` even after logging in, causing confusion or redundant navigation.
- This ensures a smoother UX by taking logged-in users directly to the main action page.

### Technical notes
- Auth state is now persisted using `localStorage`.
- Root page includes a check on mount to redirect authenticated users.

### Related improvements
- Login persistence also improves user experience across reloads and navigation.

