### PR TITLE
fix: validate fields before sending to backend to run algo #3

### DIFF
--- a/app/create/gp/page.js
+++ b/app/create/gp/page.js
@@ -99,7 +99,46 @@ export default function ConfigureGP() {
 
     const router = useRouter();
 
+    const validateInput = () => {
+        if (!["eaSimple", "eaMuPlusLambda", "eaMuCommaLambda", "eaGenerateUpdate"].includes(chosenAlgo)) {
+          alert("Invalid algorithm! Choose a supported GP algorithm.");
+          return false;
+        }
+        if (populationSize <= 0) {
+          alert("Population size must be greater than 0!!");
+          return false;
+        }
+        if (generations <= 0) {
+          alert("Generations must be greater than 0!!");
+          return false;
+        }
+        if (cxpb < 0 || cxpb > 1) {
+          alert("Crossover probability must be between 0 and 1!!");
+          return false;
+        }
+        if (mutpb < 0 || mutpb > 1) {
+          alert("Mutation probability must be between 0 and 1!!");
+          return false;
+        }
+        if (!matingFunc) {
+          alert("Mating function is required!!");
+          return false;
+        }
+        if (!mutateFunc) {
+          alert("Mutation function is required!!");
+          return false;
+        }
+        if (!selectionFunction) {
+          alert("Selection function is required!!");
+          return false;
+        }
+        return true;
+      };
+
     const runGPAlgorithm = async () => {
+        if (!validateInput()) {
+            return;
+        }
         /*
         const gpConfig = {
             "algorithm": "eaSimple", // DONE
@@ -475,6 +514,7 @@ export default function ConfigureGP() {
                             <div className="mt-4">
                                 <button
                                     className="bg-foreground text-background p-2 rounded-lg w-full hover:opacity-70 active:opacity-50"
+                                    disable={!validateInput()}
                                     onClick={(e) => {
                                         e.preventDefault();
                                         setIsLoading(true);

--- a/app/create/non-gp/page.js
+++ b/app/create/non-gp/page.js
@@ -95,7 +95,46 @@ export default function ConfigureNonGP() {
         }
     }, [currentStep]);
 
+    const validateInput = () => {
+        if (!chosenAlgo) {
+            alert("Algorithm is required!!");
+            return false;
+        }
+        if (!indGen) {
+            alert("Individual generator is required!!");
+            return false;
+        }
+        if (!popFunc) {
+            alert("Population function is required!!");
+            return false;
+        }
+        if (!matingFunc) {
+            alert("Mating (crossover) function is required!!");
+            return false;
+        }
+        if (!mutateFunc) {
+            alert("Mutation function is required!!");
+            return false;
+        }
+        if (!selectFunc) {
+            alert("Selection function is required!!");
+            return false;
+        }
+        if (!evalFunc) {
+            alert("Evaluation function is required!!");
+            return false;
+        }
+        if (populationSize <= 0 || generations <= 0) {
+            alert("Population size and generations must be greater than 0!!");
+            return false;
+        }
+        return true;
+    };
+
     const runAlgorithm = async () => {
+        if (!validateInput()) {
+            return;
+        }
         /*
             algorithm: str
             individual: str
@@ -447,6 +486,7 @@ export default function ConfigureNonGP() {
                             <div className="mt-4">
                                 <button
                                     className="bg-foreground text-background p-2 rounded-lg w-full"
+                                    disabled={!validateInput()}
                                     onClick={(e) => {
                                         e.preventDefault();
                                         setIsLoading(true);

--- a/app/create/pso/page.js
+++ b/app/create/pso/page.js
@@ -58,7 +58,50 @@ export default function ConfigurePSO() {
 
     const router = useRouter();
 
+    const validateInput = () => {
+        if (!["original", "multiswarm", "speciation"].includes(algorithm)) {
+          alert("Invalid PSO algorithm. Choose original, multiswarm, or speciation!!");
+          return false;
+        }
+        if (dimensions <= 0) {
+          alert("Dimensions must be greater than 0!!");
+          return false;
+        }
+        if (minPosition >= maxPosition) {
+          alert("Min position must be less than max position!!");
+          return false;
+        }
+        if (minSpeed >= maxSpeed) {
+          alert("Min speed must be less than max speed!!");
+          return false;
+        }
+        if (
+          ![
+            "rand", "plane", "sphere", "cigar", "rosenbrock", "h1", "ackley", "bohachevsky",
+            "griewank", "rastrigin", "rastrigin_scaled", "rastrigin_skew", "schaffer",
+            "schwefel", "himmelblau"
+          ].includes(benchmark)
+        ) {
+          alert("Invalid benchmark function selected!!");
+          return false;
+        }
+        if (populationSize <= 0) {
+          alert("Population size must be greater than 0!!");
+          return false;
+        }
+        if (generations <= 0) {
+          alert("Generations must be greater than 0!!");
+          return false;
+        }
+        return true;
+      };
+
     const runPSO = async () => {
+
+        if(!validateInput()){
+            return;
+        }
+
         const inputData = {
             algorithm: algorithm,
             dimensions: parseInt(dimensions.toString()),
@@ -266,6 +309,7 @@ export default function ConfigurePSO() {
                             <div className="mt-4">
                                 <button
                                     className="bg-foreground text-background p-2 rounded-lg w-full hover:opacity-70 active:opacity-50"
+                                    disable={!validateInput()}
                                     onClick={(e) => {
                                         e.preventDefault();
                                         setIsLoading(true);


### PR DESCRIPTION
This PR adds frontend validation to ensure all required fields are filled before executing algorithms in the GP, Non-GP, and PSO pages.
The Execute Algorithm button is now disabled when required fields are missing, preventing invalid API requests.

Implementation Details:
	•	Referred to the Runner Controller service, where validation logic for similar parameters already exists.
	•	Implemented corresponding validation checks on the frontend for consistency with backend expectations.
	•	Added alert messages for missing or invalid input values.