### PR TITLE
feat: Integrate EvOC Research Paper into Website and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,31 @@ npm run dev
 ```bash
 npm run build && npm run start
 ```
+
+
+## 📄 Citation
+
+If you use EvOC in your research or for a scientific publication, please consider citing the following paper:
+
+> Prithiviraj Ashrock, Srivathsan S, and Madhavan S. (2024). **EvOC: A Framework for Visualizing and Evolving Cellular Automata in Unity**. In *Proceedings of the Genetic and Evolutionary Computation Conference Companion (GECCO '24 Companion)*. Association for Computing Machinery, New York, NY, USA, 257–258.
+>
+> **DOI:** https://doi.org/10.1145/3712255.3726652
+
+**BibTeX entry:**
+
+```bibtex
+@inproceedings{evoc2024gecco,
+  author = {Ashrock, Prithiviraj and S, Srivathsan and S, Madhavan},
+  title = {EvOC: A Framework for Visualizing and Evolving Cellular Automata in Unity},
+  year = {2024},
+  isbn = {9798400706243},
+  publisher = {Association for Computing Machinery},
+  address = {New York, NY, USA},
+  url = {[https://doi.org/10.1145/3712255.3726652](https://doi.org/10.1145/3712255.3726652)},
+  doi = {10.1145/3712255.3726652},
+  booktitle = {Proceedings of the Genetic and Evolutionary Computation Conference Companion},
+  pages = {257–258},
+  numpages = {2},
+  location = {Melbourne, VIC, Australia},
+  series = {GECCO '24 Companion}
+}

--- a/app/page.js
+++ b/app/page.js
@@ -4,38 +4,57 @@ import Link from "next/link";
 
 export default function Home() {
     return (
-        <div className="min-h-screen flex flex-col items-center justify-between p-8 sm:p-20 bg-background font-[family-name:var(--font-geist-mono)]">
-            <main className="flex flex-col items-center gap-6 flex-grow justify-center">
-                <div className="flex items-center justify-center overflow-hidden h-40">
-                    <Image
-                        src="/LOGO.png"
-                        alt="EVOLVE OnClick logo"
-                        height={360}
-                        width={720}
-                    />
+        <div className="min-h-screen flex flex-col items-center p-8 sm:p-20 bg-background font-[family-name:var(--font-geist-mono)]">
+            <main className="flex flex-col items-center flex-grow w-full max-w-3xl">
+                <div className="flex flex-col items-center justify-center flex-1 w-full">
+                    <div className="flex items-center justify-center overflow-hidden h-40 mb-8">
+                        <Image
+                            src="/LOGO.png"
+                            alt="EVOLVE OnClick logo"
+                            height={360}
+                            width={720}
+                            priority
+                        />
+                    </div>
+
+                    <div className="flex flex-col sm:flex-row gap-4 items-center font-bold w-full max-w-md">
+                        <Link
+                            className="rounded-full border border-solid border-black transition-colors flex items-center justify-center bg-background text-foreground gap-2 hover:bg-gray-100 text-sm sm:text-base p-4 w-full h-12"
+                            href="/auth"
+                        >
+                            <Pickaxe size={24} />
+                            Get Started
+                        </Link>
+                        <Link
+                            className="rounded-full transition-colors flex items-center justify-center bg-yellow-400 text-black hover:bg-yellow-50 text-sm sm:text-base h-12 p-4 w-full border border-black gap-2"
+                            href="https://evolutionary-algorithms-on-click.github.io/user_docs/"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            <BookUp2 size={24} />
+                            Read our docs
+                        </Link>
+                    </div>
                 </div>
 
-                <div className="flex flex-col sm:flex-row gap-4 items-center font-bold">
-                    <Link
-                        className="rounded-full border border-solid border-black transition-colors flex items-center justify-center bg-background text-foreground gap-2 hover:bg-gray-100 text-sm sm:text-base p-4 w-full md:w-fit h-12"
-                        href="/auth"
-                    >
-                        <Pickaxe size={24} />
-                        Get Started
-                    </Link>
-                    <Link
-                        className="rounded-full transition-colors flex items-center justify-center bg-yellow-400 text-black hover:bg-yellow-50 text-sm sm:text-base h-12 p-4 w-full md:w-fit border border-black gap-2"
-                        href="https://evolutionary-algorithms-on-click.github.io/user_docs/"
+                <div className="mt-auto pt-12 w-full max-w-md text-center">
+                    <p className="text-foreground/70 text-xs sm:text-sm mb-4">
+                        Explore the foundational research behind EvOC's innovative approach.
+                    </p>
+                    <a
+                        className="inline-flex items-center justify-center rounded-full border border-black bg-background px-6 py-3 text-xs sm:text-sm text-foreground transition-colors hover:bg-yellow-400 hover:text-black"
+                        href="https://dl.acm.org/doi/10.1145/3712255.3726652"
                         target="_blank"
+                        rel="noopener noreferrer"
                     >
-                        <BookUp2 size={24} />
-                        Read our docs
-                    </Link>
+                        Read the Research Paper
+                    </a>
                 </div>
             </main>
-            <footer className="flex gap-6 flex-wrap items-center justify-center py-4">
+
+            <footer className="mt-12 flex items-center justify-center py-4 w-full">
                 <Link
-                    className="flex items-center gap-2 hover:underline hover:underline-offset-4 text-foreground"
+                    className="flex items-center gap-2 text-sm text-foreground hover:underline hover:underline-offset-4"
                     href="https://github.com/orgs/Evolutionary-Algorithms-On-Click/repositories"
                     target="_blank"
                     rel="noopener noreferrer"
@@ -43,9 +62,9 @@ export default function Home() {
                     <Image
                         aria-hidden
                         src="/org.jpg"
-                        alt="Globe icon"
-                        width={30}
-                        height={30}
+                        alt="Organization logo"
+                        width={24}
+                        height={24}
                         className="rounded-full"
                     />
                     Source Code →


### PR DESCRIPTION
This pull request resolves issue #79 by integrating the official EvOC research paper into the project's website and documentation. These changes make the project's academic foundation clear and easily accessible.

### Changes Made

* **Website Integration:** A new section has been added to the main landing page. It features a brief description of the paper and a button that links directly to the publication on the ACM Digital Library. This provides immediate context for visitors.
* **README Update:** A `## 📄 Citation` section has been added to the `README.md` file. This includes a human-readable reference and a complete BibTeX entry, allowing other researchers to cite this work correctly.

This implementation ensures that both end-users and developers can easily find and reference the foundational research behind the EvOC framework.

<img width="1411" height="710" alt="image" src="https://github.com/user-attachments/assets/f21506d9-0066-4c39-82ae-cdb6ccce0831" />
<img width="1411" height="707" alt="image" src="https://github.com/user-attachments/assets/c9738400-4546-44c5-956f-83739159748a" />
^when hovering or clicking

Please let me know if you have any feedback or require any changes. Thank you!